### PR TITLE
Update glyph.rs

### DIFF
--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -75,7 +75,7 @@ fn parse_bitmap_row(line: &Line<'_>, bitmap: &mut Vec<u8>) -> Result<(), ()> {
     // Accessing the UTF-8 string by byte and not by char is OK because the
     // hex conversion will fail for non ASCII inputs.
     for hex in line.keyword.as_bytes().chunks_exact(2) {
-        let byte = str::from_utf8(hex)
+        let byte = std::str::from_utf8(hex)
             .ok()
             .and_then(|s| u8::from_str_radix(s, 16).ok())
             .ok_or(())?;


### PR DESCRIPTION
change str:: to std::str:: to get rid of the error "use of unstable library feature inherent_str_constructors see issue #131114 https://github.com/rust-lang/rust/issues/131114 for more information (rustc E0658)"

relevant issue: https://github.com/rust-lang/rust/issues/131114